### PR TITLE
Deploy and Reload commands

### DIFF
--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -1,0 +1,107 @@
+const { REST } = require('@discordjs/rest');
+const { Routes } = require('discord-api-types/v9');
+const { SlashCommandBuilder, PermissionFlagsBits } = require(`discord.js`);
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+const dotenv_1 = __importDefault(require("dotenv"));
+dotenv_1.default.config();
+const token = process.env.TOKEN;
+const fs = require('node:fs');
+const rest = new REST({ version: '9' }).setToken(token);
+
+const servers = [
+    { name: 'Tentacult', value: '753099492554702908' },
+    { name: 'NQTSupport', value: '1042098513082851328' },
+    { name: 'Here', value: 'here' },
+    { name: 'Global', value: 'global' },
+]
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('deploy')
+        .setDescription('Deploys slash commands.')
+        .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers)
+        .addStringOption(option => option.setName('server').setDescription('Servers to deploy slash commands.').setRequired(true).addChoices(...servers)),
+    type: "dev",
+    async execute(interaction) {
+        try {
+            const mesmember = interaction.member;
+            if (!((mesmember.id == `284926618714243074`) || (mesmember.id == `366608657259167744`))) {
+                return interaction.reply('NQT developers only.')
+            }
+
+            const clientId = `${interaction.client.application.id}`;
+            const globalsh = [];
+            const takosh = [];
+            const devsh = [];
+            const slashfiles = fs.readdirSync('./commands').filter(file => file.endsWith('.js'));
+
+            for (const file of slashfiles) {
+                const command = require(`../commands/${file}`);
+
+                switch (command.type) {
+                    case "global": {
+                        globalsh.push(command.data.toJSON());
+                        break;
+                    }
+                    case "tako": {
+                        takosh.push(command.data.toJSON());
+                        break;
+                    }
+                    case "dev": {
+                        devsh.push(command.data.toJSON());
+                        break;
+                    }
+                }
+            }
+
+            (async () => {
+                try {
+                    console.log('Started refreshing application (/) commands.');
+                    const servid = interaction.options.getString('server');
+
+                    if (servid == "global") {
+                        await rest.put(
+                            Routes.applicationCommands(clientId),
+                            { body: globalsh },
+                        );
+                        interaction.reply(`¡Slash commands deployed globaly!`);
+                    } else if (servid == "here") {
+                        let commands = [...globalsh,...takosh,...devsh];
+                        await rest.put(
+                            Routes.applicationGuildCommands(clientId, `${interaction.guild.id}`),
+                            { body: commands },
+                        );
+                        interaction.reply(`¡Slash commands deployed on this server!`);
+                    } else if (servid == "753099492554702908") {
+                        await rest.put(
+                            Routes.applicationGuildCommands(clientId, servid),
+                            { body: takosh },
+                        );
+                        interaction.reply(`¡Slash commands deployed on the Tentacult Temple!`);
+                    } else if (servid == "1042098513082851328") {
+                        await rest.put(
+                            Routes.applicationGuildCommands(clientId, servid),
+                            { body: devsh },
+                        );
+                        interaction.reply(`¡Slash commands deployed on NQT Support!`);
+                    }
+
+                    console.log('Successfully reloaded application (/) commands.');
+
+                } catch (error) {
+                    console.error(error);
+                    interaction.reply(`Unable to deploy the slash commands.`);
+                }
+            })();
+
+        } catch (e) {
+            console.log(e);
+            return interaction.reply(`Unable to deploy the slash commands.`);
+        }
+
+
+    },
+};
+

--- a/src/commands/reload.js
+++ b/src/commands/reload.js
@@ -1,0 +1,125 @@
+var fs = require('fs');
+const { SlashCommandBuilder, PermissionFlagsBits } = require(`discord.js`);
+var cfiles = fs.readdirSync('./commands');
+var pfiles = fs.readdirSync('./passives');
+var ffiles = fs.readdirSync('./functions');
+
+const coption = [];
+
+for (const file of cfiles) {
+    let cname = file.replace(".js", "")
+    coption.push({ name: `${cname}`, value: `${cname}` })
+}
+
+for (const file of pfiles) {
+    let cname = file.replace(".js", "")
+    coption.push({ name: `${cname}`, value: `${cname}` })
+}
+
+for (const file of ffiles) {
+    let cname = file.replace(".js", "")
+    coption.push({ name: `${cname}`, value: `${cname}` })
+}
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('reload')
+        .setDescription('Reload the given slash command.')
+        .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers)
+        .addStringOption(option => option.setName('command').setDescription('The command to be reloaded.').setRequired(true).addChoices(...coption)),
+    type: "dev",
+    async execute(interaction) {
+
+        const mesmember = interaction.member;
+        let client = interaction.client;
+
+        let cName = interaction.options.getString('command');
+        const wordInString = (s, word) => new RegExp('\\b' + word + '\\b', 'gi').test(s);
+        var FinalType = `Error`;
+        try {
+
+            const cpath = Object.keys(require.cache).find(f => wordInString(`${f}`, `${cName}`))
+
+            if (cpath != undefined) {
+                var typepath = cpath.slice(0, cpath.lastIndexOf("\\")); //CHANGE THE BACK SLASH TO NORMAL SLASH
+                typepath = typepath.slice(typepath.lastIndexOf('\\') + 1)
+
+                console.log(cpath, typepath);
+
+                await delete require.cache[require.resolve(`${cpath}`)]
+                switch (typepath) {
+                    case `commands`: {
+                        client.commands.delete(cName)
+                        const push = require(`${cpath}`)
+                        client.commands.set(cName, push)
+                        FinalType = `Slash`
+                        break;
+                    }
+                    case `passives`: {
+                        client.passives.delete(cName)
+                        const push = require(`${cpath}`)
+                        client.passives.set(cName, push)
+                        FinalType = `Passive`
+                        break;
+                    }
+                    case `functions`: {
+                        client.functions.delete(cName)
+                        const push = require(`${cpath}`)
+                        client.functions.set(cName, push)
+                        FinalType = `Function`
+                        break;
+                    }
+                }
+            } else {
+
+                var cfiles = fs.readdirSync('./commands');
+                var pfiles = fs.readdirSync('./passives');
+                var ffiles = fs.readdirSync('./functions');
+
+                var pathfind = cfiles.find(f => wordInString(`${f}`, `${cName}`)) ? `../commands/` + `${cName}.js` :
+                    pfiles.find(f => wordInString(`${f}`, `${cName}`)) ? `../passives/` + `${cName}.js` :
+                        ffiles.find(f => wordInString(`${f}`, `${cName}`)) ? `../functions/` + `${cName}.js` :
+                            undefined;
+
+                var typepath = cfiles.find(f => wordInString(`${f}`, `${cName}`)) ? `commands` :
+                    pfiles.find(f => wordInString(`${f}`, `${cName}`)) ? `passives` :
+                        ffiles.find(f => wordInString(`${f}`, `${cName}`)) ? `functions` :
+                            undefined;
+
+                if (pathfind != undefined) {
+
+                    switch (typepath) {
+                        case `commands`: {
+                            const push = require(`${pathfind}`)
+                            client.commands.commands.set(cName, push)
+                            FinalType = `Slash`
+                            break;
+                        }
+                        case `passives`: {
+                            const push = require(`${pathfind}`)
+                            client.commands.passives.set(cName, push)
+                            FinalType = `Passive`
+                            break;
+                        }
+                        case `functions`: {
+                            const push = require(`${pathfind}`)
+                            client.commands.slash.set(cName, push)
+                            FinalType = `Function`
+                            break;
+                        }
+                    }
+
+                } else {
+                    interaction.reply(`Command does not exist: **${cName}**`)
+                }
+            }
+
+        } catch (e) {
+            console.log(e);
+            return interaction.reply(`Unable to reload the command **${cName}**`)
+        }
+        interaction.reply(`¡${FinalType} command **${cName}** reloaded!`)
+
+    },
+};
+


### PR DESCRIPTION
Deploy allows for making public and or available slash commands. Reload allows for editing and updating passive and slash commands without restarting NQT.