### PR TITLE
feat: echo command with role mention security; generalized nqt ping check for takotalks

### DIFF
--- a/src/commands/echo.js
+++ b/src/commands/echo.js
@@ -1,0 +1,57 @@
+const {SlashCommandBuilder, PermissionFlagsBits, ChannelType, EmbedBuilder} = require("discord.js");
+
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('echo')
+        .setDescription('Sends a message in the specified channel.')
+        .setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages)
+        .addStringOption(option =>
+            option
+                .setName('message')
+                .setDescription('The message to be sent.')
+                .setRequired(true)
+        )
+        .addChannelOption(option =>
+            option
+                .setName('channel')
+                .setDescription('The channel where the message will be sent.')
+                .addChannelTypes(ChannelType.GuildAnnouncement, ChannelType.GuildText)
+                .setRequired(true)
+        )
+        .addRoleOption(option =>
+            option
+                .setName('role')
+                .setDescription('If you intend to ping a role please specify it here, as it won\'t be pinged otherwise.')
+        ),
+    async execute(interaction) {
+        await interaction.deferReply({ephemeral: true});
+
+        const messageContent = interaction.options.getString('message', true);
+        const channel = interaction.options.getChannel('channel', true);
+        const role = interaction.options.getRole('role');
+
+        const message = await channel.send({
+            content: messageContent,
+            allowedMentions: { parse: ['users'], roles: role ? [role.id] : [] }
+        })
+
+        if (!message) {
+            return interaction.editReply({
+                embeds: [
+                    new EmbedBuilder()
+                        .setColor('#D0312D')
+                        .setDescription('There was an issue with sending the message!')
+                ]
+            });
+        }
+
+        return interaction.editReply({
+            embeds: [
+                new EmbedBuilder()
+                    .setColor('#5DBB63')
+                    .setDescription(`[Message has been sent.](${message.url})`)
+            ]
+        });
+    }
+}

--- a/src/passives/takotalks.js
+++ b/src/passives/takotalks.js
@@ -6,7 +6,7 @@ module.exports = {
     async execute(message) {
         const client = message.client;
 
-        if(message.content.includes(`<@978098134767009843>`)){
+        if(message.mentions.users.some(user => user.id === client.user.id)){
             message.channel.send(`<:InaHi:1064654919262535800> <:rockdachi:1011431424601116804>`)
         }
 


### PR DESCRIPTION
Added the echo command, it has some security against role pings and doesn't allow everyone or here pings ever, although that can be arranged if wanted.

Changed takotalks so that the bot replies whenever mentioned regardless of the client's id as I was trying to test it and thought a generalization would work better.